### PR TITLE
Add initial devtools_options.yaml configuration file

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:


### PR DESCRIPTION
This pull request includes changes to the `devtools_options.yaml` file to add descriptions and documentation references for Dart & Flutter DevTools settings.

Documentation and Descriptions:

* [`devtools_options.yaml`](diffhunk://#diff-74b02520cb30233ed12dff30d25e25e1f9af8bb932111444d30f0d47b0b77957R1-R3): Added a description and documentation URL to provide context and guidance on configuring extension enablement states for Dart & Flutter DevTools.